### PR TITLE
Add ability to load from realm file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-database",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A nicer interface for the react native flavour of realm",
   "repository": "https://github.com/sussol/react-native-database.git",
   "author": "Sustainable Solutions (NZ) Ltd.",

--- a/src/Database.js
+++ b/src/Database.js
@@ -8,10 +8,12 @@ export class Database {
    * Create a new database with the given schema.
    * @param  {object} schema Contains a schema and a schemaVersion, in the format
    *                         expected by Realm
+   * @param  {object} extraFields Extra fields to initialise realm database with
+   *                         new database(schema, { path: 'pathToFile.realm' });
    * @return {none}
    */
-  constructor(schema) {
-    this.realm = new Realm(schema);
+  constructor(schema, extraFields) {
+    this.realm = new Realm({ ...extraFields, ...schema });
     this.listeners = new Map();
   }
 

--- a/src/Database.js
+++ b/src/Database.js
@@ -12,7 +12,7 @@ export class Database {
    *                         new database(schema, { path: 'pathToFile.realm' });
    * @return {none}
    */
-  constructor(schema, extraFields) {
+  constructor(schema, extraFields = {}) {
     this.realm = new Realm({ ...extraFields, ...schema });
     this.listeners = new Map();
   }


### PR DESCRIPTION
@edmofro, @joshxg, @Chris-Petty this can be very useful if you using realm:

if you ever want to load realm file with data, and use that realm file on app start up:
copy realm file to ./android/app/src/main/assets, then add this to ./src/main.js ->
```
function App() {
  Realm.copyBundledRealmFiles();
...
  return ( ...
```
then in when initialising the db
```
import RNFS from 'react-native-fs';
...
 const database = new Database(schema, { path: `${RNFS.DocumentDirectoryPath}/myrealmfile.realm` });
```
starting with only path parameter, but then realise it would be useful to be able to pass other like readOnly
